### PR TITLE
fix(update): MHAM-1042-Zephyr-updates-required-for-ATSENSE-CODEC-event-handling

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -2031,9 +2031,11 @@ __syscall void k_event_init(struct k_event *event);
  * the current set of events tracked by the event object.
  *
  * @param event Address of the event object
- * @param events Set of events to post to @a event
+ * @param events Set of events to set in @a event
+ *
+ * @retval Previous value of the events in @a event
  */
-__syscall void k_event_post(struct k_event *event, uint32_t events);
+__syscall uint32_t k_event_post(struct k_event *event, uint32_t events);
 
 /**
  * @brief Set the events in an event object
@@ -2046,9 +2048,40 @@ __syscall void k_event_post(struct k_event *event, uint32_t events);
  * events tracked by the event object.
  *
  * @param event Address of the event object
- * @param events Set of events to post to @a event
+ * @param events Set of events to set/clear in @a event
+ *
+ * @retval Previous value of the events in @a event
  */
-__syscall void k_event_set(struct k_event *event, uint32_t events);
+__syscall uint32_t k_event_set(struct k_event *event, uint32_t events);
+
+/**
+ * @brief Set or clear the events in an event object
+ *
+ * This routine sets the events stored in event object to the specified value.
+ * All tasks waiting on the event object @a event whose waiting conditions
+ * become met by this immediately unpend. Unlike @ref k_event_set, this routine
+ * allows specific event bits to be set and cleared as determined by the mask.
+ *
+ * @param event Address of the event object
+ * @param events Set of events to post to @a event
+ * @param events_mask Mask to be applied to @a events
+ *
+ * @retval Previous value of the events in @a event
+ */
+__syscall uint32_t k_event_set_masked(struct k_event *event, uint32_t events,
+				  uint32_t events_mask);
+
+/**
+ * @brief Clear the events in an event object
+ *
+ * This routine clears (resets) the specified events stored in an event object.
+ *
+ * @param event Address of the event object
+ * @param events Set of events to clear in @a event
+ *
+ * @retval Previous value of the events in @a event
+ */
+__syscall uint32_t k_event_clear(struct k_event *event, uint32_t events);
 
 /**
  * @brief Wait for any of the specified events
@@ -2075,7 +2108,7 @@ __syscall uint32_t k_event_wait(struct k_event *event, uint32_t events,
 				bool reset, k_timeout_t timeout);
 
 /**
- * @brief Wait for any of the specified events
+ * @brief Wait for all of the specified events
  *
  * This routine waits on event object @a event until all of the specified
  * events have been delivered to the event object, or the maximum wait time

--- a/include/tracing/tracing.h
+++ b/include/tracing/tracing.h
@@ -1870,9 +1870,9 @@
  * @brief Trace posting of an Event call entry
  * @param event Event object
  * @param events Set of posted events
- * @param accumulate True if events accumulate, false otherwise
+ * @param events_mask Mask to apply against posted events
  */
-#define sys_port_trace_k_event_post_enter(event, events, accumulate)
+#define sys_port_trace_k_event_post_enter(event, events, events_mask)
 
 /**
  * @brief Trace posting of an Event call exit
@@ -1880,7 +1880,7 @@
  * @param events Set of posted events
  * @param accumulate True if events accumulate, false otherwise
  */
-#define sys_port_trace_k_event_post_exit(event, events, accumulate)
+#define sys_port_trace_k_event_post_exit(event, events, events_mask)
 
 /**
  * @brief Trace waiting of an Event call entry

--- a/subsys/tracing/ctf/tracing_ctf.h
+++ b/subsys/tracing/ctf/tracing_ctf.h
@@ -314,8 +314,8 @@ extern "C" {
 #define sys_port_trace_k_timer_status_sync_exit(timer, result)
 
 #define sys_port_trace_k_event_init(event)
-#define sys_port_trace_k_event_post_enter(event, events, accumulate)
-#define sys_port_trace_k_event_post_exit(event, events, accumulate)
+#define sys_port_trace_k_event_post_enter(event, events, events_mask)
+#define sys_port_trace_k_event_post_exit(event, events, events_mask)
 #define sys_port_trace_k_event_wait_enter(event, events, options, timeout)
 #define sys_port_trace_k_event_wait_blocking(event, events, options, timeout)
 #define sys_port_trace_k_event_wait_exit(event, events, ret)

--- a/subsys/tracing/test/tracing_test.h
+++ b/subsys/tracing/test/tracing_test.h
@@ -421,10 +421,10 @@
 	sys_trace_k_timer_status_sync_exit(timer, result)
 
 #define sys_port_trace_k_event_init(event) sys_trace_k_event_init(event)
-#define sys_port_trace_k_event_post_enter(event, events, accumulate)   \
-	sys_trace_k_event_post_enter(event, events, accumulate)
-#define sys_port_trace_k_event_post_exit(event, events, accumulate)   \
-	sys_trace_k_event_post_exit(event, events, accumulate)
+#define sys_port_trace_k_event_post_enter(event, events, events_mask)   \
+	sys_trace_k_event_post_enter(event, events, events_mask)
+#define sys_port_trace_k_event_post_exit(event, events, events_mask)  \
+	sys_trace_k_event_post_exit(event, events, events_mask)
 #define sys_port_trace_k_event_wait_enter(event, events, options, timeout)   \
 	sys_trace_k_event_wait_enter(event, events, options, timeout)
 #define sys_port_trace_k_event_wait_blocking(event, events, options, timeout) \

--- a/subsys/tracing/user/tracing_user.h
+++ b/subsys/tracing/user/tracing_user.h
@@ -296,8 +296,8 @@ void sys_trace_idle(void);
 #define sys_port_trace_k_timer_status_sync_exit(timer, result)
 
 #define sys_port_trace_k_event_init(event)
-#define sys_port_trace_k_event_post_enter(event, events, accumulate)
-#define sys_port_trace_k_event_post_exit(event, events, accumulate)
+#define sys_port_trace_k_event_post_enter(event, events, events_mask)
+#define sys_port_trace_k_event_post_exit(event, events, events_mask)
 #define sys_port_trace_k_event_wait_enter(event, events, options, timeout)
 #define sys_port_trace_k_event_wait_blocking(event, events, options, timeout)
 #define sys_port_trace_k_event_wait_exit(event, events, ret)

--- a/tests/kernel/events/event_api/src/test_event_apis.c
+++ b/tests/kernel/events/event_api/src/test_event_apis.c
@@ -340,6 +340,7 @@ void test_event_deliver(void)
 {
 	static struct k_event  event;
 	uint32_t  events;
+	uint32_t  events_mask;
 
 	k_event_init(&event);
 
@@ -360,6 +361,28 @@ void test_event_deliver(void)
 
 	events = 0xAAAA0000;
 	k_event_set(&event, events);
+	zassert_true(event.events == events, NULL);
+
+	/*
+	 * Verify k_event_set_masked() update the events
+	 * stored in the event object as expected
+	 */
+	events = 0x33333333;
+	k_event_set(&event, events);
+	zassert_true(event.events == events, NULL);
+	events_mask = 0x11111111;
+	k_event_set_masked(&event, 0, events_mask);
+	zassert_true(event.events == 0x22222222, NULL);
+	events_mask = 0x22222222;
+	k_event_set_masked(&event, 0, events_mask);
+	zassert_true(event.events == 0, NULL);
+	events = 0x22222222;
+	events_mask = 0x22222222;
+	k_event_set_masked(&event, events, events_mask);
+	zassert_true(event.events == events, NULL);
+	events = 0x11111111;
+	events_mask = 0x33333333;
+	k_event_set_masked(&event, events, events_mask);
 	zassert_true(event.events == events, NULL);
 }
 


### PR DESCRIPTION
Zephyr v3.0.0 has partial support for event handling. 
To change from using the polling API to events API, some updates are required to the events.c.
Updates taken from the following four commits:
1. [kernel: Use mask rather than boolean to update events](https://github.com/zephyrproject-rtos/zephyr/commit/e7e827a0d2c3f8f1e852a436d91fb867e9d4f98f)
2. [kernel: Add k_event_set_masked primitive](https://github.com/zephyrproject-rtos/zephyr/commit/e1836718082c8b24a31372373b69d6b52546b09b)
3. [kernel: events: fix doc typo and remove empty lines](https://github.com/zephyrproject-rtos/zephyr/commit/58ece9d503c63dd4d91a8bf0dd095f7952cc85d7)
4. [kernel: events: add function to clear events](https://github.com/zephyrproject-rtos/zephyr/commit/caba2ad6168634e7031d10d62ddad01a9138a556)

![image](https://github.com/user-attachments/assets/6662180b-8fe8-478a-946f-404cd8ced081)
