### PR TITLE
Fix/mham 1042 event handling cherry pick

### DIFF
--- a/include/kernel.h
+++ b/include/kernel.h
@@ -2051,6 +2051,21 @@ __syscall void k_event_post(struct k_event *event, uint32_t events);
 __syscall void k_event_set(struct k_event *event, uint32_t events);
 
 /**
+ * @brief Set or clear the events in an event object
+ *
+ * This routine sets the events stored in event object to the specified value.
+ * All tasks waiting on the event object @a event whose waiting conditions
+ * become met by this immediately unpend. Unlike @ref k_event_set, this routine
+ * allows specific event bits to be set and cleared as determined by the mask.
+ *
+ * @param event Address of the event object
+ * @param events Set of events to post to @a event
+ * @param events_mask Mask to be applied to @a events
+ */
+__syscall void k_event_set_masked(struct k_event *event, uint32_t events,
+				  uint32_t events_mask);
+
+/**
  * @brief Wait for any of the specified events
  *
  * This routine waits on event object @a event until any of the specified

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -2066,6 +2066,16 @@ __syscall void k_event_set_masked(struct k_event *event, uint32_t events,
 				  uint32_t events_mask);
 
 /**
+ * @brief Clear the events in an event object
+ *
+ * This routine clears (resets) the specified events stored in an event object.
+ *
+ * @param event Address of the event object
+ * @param events Set of events to clear in @a event
+ */
+__syscall void k_event_clear(struct k_event *event, uint32_t events);
+
+/**
  * @brief Wait for any of the specified events
  *
  * This routine waits on event object @a event until any of the specified

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -2046,7 +2046,7 @@ __syscall void k_event_post(struct k_event *event, uint32_t events);
  * events tracked by the event object.
  *
  * @param event Address of the event object
- * @param events Set of events to post to @a event
+ * @param events Set of events to set in @a event
  */
 __syscall void k_event_set(struct k_event *event, uint32_t events);
 
@@ -2059,7 +2059,7 @@ __syscall void k_event_set(struct k_event *event, uint32_t events);
  * allows specific event bits to be set and cleared as determined by the mask.
  *
  * @param event Address of the event object
- * @param events Set of events to post to @a event
+ * @param events Set of events to set/clear in @a event
  * @param events_mask Mask to be applied to @a events
  */
 __syscall void k_event_set_masked(struct k_event *event, uint32_t events,
@@ -2090,7 +2090,7 @@ __syscall uint32_t k_event_wait(struct k_event *event, uint32_t events,
 				bool reset, k_timeout_t timeout);
 
 /**
- * @brief Wait for any of the specified events
+ * @brief Wait for all of the specified events
  *
  * This routine waits on event object @a event until all of the specified
  * events have been delivered to the event object, or the maximum wait time

--- a/include/tracing/tracing.h
+++ b/include/tracing/tracing.h
@@ -1870,17 +1870,17 @@
  * @brief Trace posting of an Event call entry
  * @param event Event object
  * @param events Set of posted events
- * @param accumulate True if events accumulate, false otherwise
+ * @param events_mask Mask to apply against posted events
  */
-#define sys_port_trace_k_event_post_enter(event, events, accumulate)
+#define sys_port_trace_k_event_post_enter(event, events, events_mask)
 
 /**
  * @brief Trace posting of an Event call exit
  * @param event Event object
  * @param events Set of posted events
- * @param accumulate True if events accumulate, false otherwise
+ * @param events_mask Mask to apply against posted events
  */
-#define sys_port_trace_k_event_post_exit(event, events, accumulate)
+#define sys_port_trace_k_event_post_exit(event, events, events_mask)
 
 /**
  * @brief Trace waiting of an Event call entry

--- a/kernel/events.c
+++ b/kernel/events.c
@@ -174,6 +174,22 @@ void z_vrfy_k_event_set(struct k_event *event, uint32_t events)
 #include <syscalls/k_event_set_mrsh.c>
 #endif
 
+void z_impl_k_event_set_masked(struct k_event *event, uint32_t events,
+			       uint32_t events_mask)
+{
+	k_event_post_internal(event, events, events_mask);
+}
+
+#ifdef CONFIG_USERSPACE
+void z_vrfy_k_event_set_masked(struct k_event *event, uint32_t events,
+			       uint32_t events_mask)
+{
+	Z_OOPS(Z_SYSCALL_OBJ(event, K_OBJ_EVENT));
+	z_impl_k_event_set_masked(event, events, events_mask);
+}
+#include <syscalls/k_event_set_masked_mrsh.c>
+#endif
+
 static uint32_t k_event_wait_internal(struct k_event *event, uint32_t events,
 				      unsigned int options, k_timeout_t timeout)
 {

--- a/kernel/events.c
+++ b/kernel/events.c
@@ -85,7 +85,7 @@ static bool are_wait_conditions_met(uint32_t desired, uint32_t current,
 }
 
 static void k_event_post_internal(struct k_event *event, uint32_t events,
-				  bool accumulate)
+				  uint32_t events_mask)
 {
 	k_spinlock_key_t  key;
 	struct k_thread  *thread;
@@ -95,12 +95,10 @@ static void k_event_post_internal(struct k_event *event, uint32_t events,
 	key = k_spin_lock(&event->lock);
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_event, post, event, events,
-					accumulate);
+					events_mask);
 
-	if (accumulate) {
-		events |= event->events;
-	}
-
+	events = (event->events & ~events_mask) |
+		 (events & events_mask);
 	event->events = events;
 
 	/*
@@ -145,12 +143,12 @@ static void k_event_post_internal(struct k_event *event, uint32_t events,
 	z_reschedule(&event->lock, key);
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_event, post, event, events,
-				       accumulate);
+				       events_mask);
 }
 
 void z_impl_k_event_post(struct k_event *event, uint32_t events)
 {
-	k_event_post_internal(event, events, true);
+	k_event_post_internal(event, events, events);
 }
 
 #ifdef CONFIG_USERSPACE
@@ -164,7 +162,7 @@ void z_vrfy_k_event_post(struct k_event *event, uint32_t events)
 
 void z_impl_k_event_set(struct k_event *event, uint32_t events)
 {
-	k_event_post_internal(event, events, false);
+	k_event_post_internal(event, events, ~0);
 }
 
 #ifdef CONFIG_USERSPACE

--- a/kernel/events.c
+++ b/kernel/events.c
@@ -188,6 +188,20 @@ void z_vrfy_k_event_set_masked(struct k_event *event, uint32_t events,
 #include <syscalls/k_event_set_masked_mrsh.c>
 #endif
 
+void z_impl_k_event_clear(struct k_event *event, uint32_t events)
+{
+	k_event_post_internal(event, 0, events);
+}
+
+#ifdef CONFIG_USERSPACE
+void z_vrfy_k_event_clear(struct k_event *event, uint32_t events)
+{
+	Z_OOPS(Z_SYSCALL_OBJ(event, K_OBJ_EVENT));
+	z_impl_k_event_clear(event, events);
+}
+#include <syscalls/k_event_clear_mrsh.c>
+#endif
+
 static uint32_t k_event_wait_internal(struct k_event *event, uint32_t events,
 				      unsigned int options, k_timeout_t timeout)
 {

--- a/kernel/events.c
+++ b/kernel/events.c
@@ -125,8 +125,6 @@ static void k_event_post_internal(struct k_event *event, uint32_t events,
 			thread->next_event_link = head;
 			head = thread;
 		}
-
-
 	}
 
 	if (head != NULL) {

--- a/subsys/tracing/ctf/tracing_ctf.h
+++ b/subsys/tracing/ctf/tracing_ctf.h
@@ -314,8 +314,8 @@ extern "C" {
 #define sys_port_trace_k_timer_status_sync_exit(timer, result)
 
 #define sys_port_trace_k_event_init(event)
-#define sys_port_trace_k_event_post_enter(event, events, accumulate)
-#define sys_port_trace_k_event_post_exit(event, events, accumulate)
+#define sys_port_trace_k_event_post_enter(event, events, events_mask)
+#define sys_port_trace_k_event_post_exit(event, events, events_mask)
 #define sys_port_trace_k_event_wait_enter(event, events, options, timeout)
 #define sys_port_trace_k_event_wait_blocking(event, events, options, timeout)
 #define sys_port_trace_k_event_wait_exit(event, events, ret)

--- a/subsys/tracing/test/tracing_test.h
+++ b/subsys/tracing/test/tracing_test.h
@@ -421,10 +421,10 @@
 	sys_trace_k_timer_status_sync_exit(timer, result)
 
 #define sys_port_trace_k_event_init(event) sys_trace_k_event_init(event)
-#define sys_port_trace_k_event_post_enter(event, events, accumulate)   \
-	sys_trace_k_event_post_enter(event, events, accumulate)
-#define sys_port_trace_k_event_post_exit(event, events, accumulate)   \
-	sys_trace_k_event_post_exit(event, events, accumulate)
+#define sys_port_trace_k_event_post_enter(event, events, events_mask)   \
+	sys_trace_k_event_post_enter(event, events, events_mask)
+#define sys_port_trace_k_event_post_exit(event, events, events_mask)   \
+	sys_trace_k_event_post_exit(event, events, events_mask)
 #define sys_port_trace_k_event_wait_enter(event, events, options, timeout)   \
 	sys_trace_k_event_wait_enter(event, events, options, timeout)
 #define sys_port_trace_k_event_wait_blocking(event, events, options, timeout) \

--- a/subsys/tracing/user/tracing_user.h
+++ b/subsys/tracing/user/tracing_user.h
@@ -296,8 +296,8 @@ void sys_trace_idle(void);
 #define sys_port_trace_k_timer_status_sync_exit(timer, result)
 
 #define sys_port_trace_k_event_init(event)
-#define sys_port_trace_k_event_post_enter(event, events, accumulate)
-#define sys_port_trace_k_event_post_exit(event, events, accumulate)
+#define sys_port_trace_k_event_post_enter(event, events, events_mask)
+#define sys_port_trace_k_event_post_exit(event, events, events_mask)
 #define sys_port_trace_k_event_wait_enter(event, events, options, timeout)
 #define sys_port_trace_k_event_wait_blocking(event, events, options, timeout)
 #define sys_port_trace_k_event_wait_exit(event, events, ret)

--- a/tests/kernel/events/event_api/src/test_event_apis.c
+++ b/tests/kernel/events/event_api/src/test_event_apis.c
@@ -340,6 +340,7 @@ void test_event_deliver(void)
 {
 	static struct k_event  event;
 	uint32_t  events;
+	uint32_t  events_mask;
 
 	k_event_init(&event);
 
@@ -361,6 +362,33 @@ void test_event_deliver(void)
 	events = 0xAAAA0000;
 	k_event_set(&event, events);
 	zassert_true(event.events == events, NULL);
+
+	/*
+	 * Verify k_event_set_masked() update the events
+	 * stored in the event object as expected
+	 */
+	events = 0x33333333;
+	k_event_set(&event, events);
+	zassert_true(event.events == events, NULL);
+
+	events_mask = 0x11111111;
+	k_event_set_masked(&event, 0, events_mask);
+	zassert_true(event.events == 0x22222222, NULL);
+
+	events_mask = 0x22222222;
+	k_event_set_masked(&event, 0, events_mask);
+	zassert_true(event.events == 0, NULL);
+
+	events = 0x22222222;
+	events_mask = 0x22222222;
+	k_event_set_masked(&event, events, events_mask);
+	zassert_true(event.events == events, NULL);
+
+	events = 0x11111111;
+	events_mask = 0x33333333;
+	k_event_set_masked(&event, events, events_mask);
+	zassert_true(event.events == events, NULL);
+
 }
 
 /**


### PR DESCRIPTION
Zephyr v3.0.0 has partial support for event handling.
To change from using the polling API to events API, some updates are required to the events.c.


Cherry picked the following commits:
1. [kernel: Use mask rather than boolean to update events](https://github.com/zephyrproject-rtos/zephyr/commit/e7e827a0d2c3f8f1e852a436d91fb867e9d4f98f)
2. [kernel: Add k_event_set_masked primitive](https://github.com/zephyrproject-rtos/zephyr/commit/e1836718082c8b24a31372373b69d6b52546b09b)
3. [kernel: events: fix doc typo and remove empty lines](https://github.com/zephyrproject-rtos/zephyr/commit/58ece9d503c63dd4d91a8bf0dd095f7952cc85d7)
4. [kernel: events: add function to clear events](https://github.com/zephyrproject-rtos/zephyr/commit/caba2ad6168634e7031d10d62ddad01a9138a556)
5. [kernel: event modification functions return previous value](https://github.com/zephyrproject-rtos/zephyr/commit/4ce1f03aa98c896713834793b3bfc6581d6ac450)